### PR TITLE
Add Rust Generator example

### DIFF
--- a/generator.rs
+++ b/generator.rs
@@ -1,0 +1,50 @@
+#![feature(generators, generator_trait)]
+
+use std::ops::{Generator, GeneratorState};
+
+/// Wrapper around a `Generator` which yields `T` and returns `()` to
+/// implement `Iterator` with item type `T`.
+///
+/// This wrapper type and implementation of `Iterator` should be unnecessary
+/// once `Generator` is stabilized and the standard library provides an
+/// equivalent implementation of `Iterator` for `Generator`.
+///
+/// I believe that this is unsafe without some way of ensuring that `G` is
+/// pinned in place.  There is work ongoing to allow pinned generators to be
+/// safely accessed, which is one of the reasons that generators are not yet
+/// stable.  This particular example is safe because we don't move the
+/// generator while iterating over it.
+struct IterGen<G>(G);
+
+impl<T, G> Iterator for IterGen<G>
+    where G: Generator<Yield=T, Return=()>
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match unsafe { self.0.resume() } {
+            GeneratorState::Yielded(x) => Some(x),
+            GeneratorState::Complete(()) => None,
+        }
+    }
+}
+
+fn triples() -> impl Iterator<Item=(i32, i32, i32)> {
+    IterGen(||
+        for z in 1.. {
+            for x in 1..=z {
+                for y in x..=z {
+                    if x*x + y*y == z*z {
+                        yield (x, y, z)
+                    }
+                }
+            }
+        }
+    )
+}
+
+fn main() {
+    for (x, y, z) in triples().take(1000) {
+        println!("({}, {}, {})", x, y, z);
+    }
+}

--- a/range.rs
+++ b/range.rs
@@ -1,5 +1,5 @@
-fn main() {
-    let triples = (1..).flat_map(|z| {
+fn triples() -> impl Iterator<Item=(i32, i32, i32)> {
+    (1..).flat_map(|z| {
         (1..=z).flat_map(move |x| {
             (x..=z).filter_map(move |y| {
                 if x * x + y * y == z * z {
@@ -9,8 +9,11 @@ fn main() {
                 }
             })
         })
-    });
-    for (x, y, z) in triples.take(1000) {
+    })
+}
+
+fn main() {
+    for (x, y, z) in triples().take(1000) {
         println!("({}, {}, {})", x, y, z);
     }
 }


### PR DESCRIPTION
`Generator` is an unstable feature available in nightly Rust, which is being
used as the basis for the `async`/`await` features that are in active
development.

It can be used to provide a much more readable version of the range/iterator
example.  To do so, we need to create a wrapper type that implements
`Iterator` around a `Generator`.  I believe that my implementation is unsafe,
so should only be used for example purposes for now; it would need to pin the
generator to ensure it doesn't move during iteration to be safe.  It's
sufficient for the purpose of this example, and there have been changes to the
`Generator` interface that should be able to make this safe, they just haven't
been implemented yet.

Also factor out triples iterator into function in Rust range example.