### PR TITLE
add simple.nim

### DIFF
--- a/simple.nim
+++ b/simple.nim
@@ -1,0 +1,26 @@
+include system/ansi_c
+
+proc main() =
+  var t = 0
+
+  block done:
+    var i = 0
+
+    var z = 1
+    while true:
+      for x in 1..z:
+        for y in x..z:
+          if x*x + y*y == z*z:
+            when defined(skip_printfs):
+              t += x+y+z
+            else:
+              c_printf("(%i, %i, %i)\n", x, y, z)
+            i.inc
+            if i == 1000:
+              break done
+      z.inc
+
+  when defined(skip_printfs):
+    c_printf("%i\n", t)
+
+main()


### PR DESCRIPTION
looks like nim version of simple.d compiles faster and runs a tiny bit faster than D version ldc of simple.d

```
nim c -d:skip_printfs -d:release --stacktrace:off simple.nim
```

gtime -v ./simple
1400652
```
        Command being timed: "./simple"
        User time (seconds): 0.13
        System time (seconds): 0.00
        Percent of CPU this job got: 97%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.14


gtime -v nim c -d:skip_printfs -d:release --stacktrace:off simple.nim
```
        Command being timed: "nim c -d:skip_printfs -d:release --stacktrace:off simple.nim"
        User time (seconds): 0.21
        System time (seconds): 0.03
        Percent of CPU this job got: 96%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.25
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 23692
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 12
        Minor (reclaiming a frame) page faults: 10175
        Voluntary context switches: 4
        Involuntary context switches: 167
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

EDIT:
check whether `system/sysio` is better than ` include system/ansi_c`